### PR TITLE
At platform specific path for Windows

### DIFF
--- a/caravel/config.py
+++ b/caravel/config.py
@@ -34,6 +34,9 @@ SECRET_KEY = '\2\1thisismyscretkey\1\2\e\y\y\h'  # noqa
 
 # The SQLAlchemy connection string.
 SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/caravel.db'
+# this is for platform specific: "nt" is for windows, "posix" is *nix (including Mac)
+if os.name == "nt":
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///c:\\tmp\\caravel.db'    
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 


### PR DESCRIPTION
Hi,
I add the path to sqlite file in case of Windows
SQLALCHEMY_DATABASE_URI = 'sqlite:///c:\tmp\caravel.db'
Because default configuration is for *nix and creates error when someone installs cravel on Win32. 
